### PR TITLE
mkr1 visitor

### DIFF
--- a/mkr1/mkr1/LightHTML/LightElementNode.cs
+++ b/mkr1/mkr1/LightHTML/LightElementNode.cs
@@ -1,5 +1,6 @@
 ﻿using mkr1.Iterator;
 using mkr1.State;
+using mkr1.Visitor;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -75,6 +76,14 @@ namespace mkr1.LightHTML
                 IteratorType.BreadthFirst => new BreadthFirstIterator(this),
                 _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
             };
+        }
+
+        public override void Accept(IVisitor visitor)
+        {
+            visitor.Visit(this);
+            foreach (var child in Children)
+                if (child is IVisitable v)
+                    v.Accept(visitor);
         }
     }
 }

--- a/mkr1/mkr1/LightHTML/LightNode.cs
+++ b/mkr1/mkr1/LightHTML/LightNode.cs
@@ -1,11 +1,14 @@
-﻿namespace mkr1.LightHTML
+﻿using mkr1.Visitor;
+
+namespace mkr1.LightHTML
 {
-    public abstract class LightNode
+    public abstract class LightNode : IVisitable
     {
         public LightNode()
         {
             OnCreated();
         }
+        public abstract void Accept(IVisitor visitor);
 
         protected virtual void OnCreated() { }
 
@@ -47,6 +50,11 @@
         }
 
         public override string InnerHTML => Text;
+
+        public override void Accept(IVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
     }
 
     public enum DisplayType { Block, Inline }

--- a/mkr1/mkr1/Program.cs
+++ b/mkr1/mkr1/Program.cs
@@ -2,11 +2,24 @@ using mkr1.LightHTML;
 using mkr1.Iterator;
 using mkr1.Command;
 using mkr1.State;
+using mkr1.Visitor;
 
 var root = GenerateRoot();
+Visitor(root);
 State();
 Iterator(root);
 Command();
+
+static void Visitor(LightElementNode root)
+{
+    var parser = new HTMLParserVisitor();
+    root.Accept(parser);
+    Console.WriteLine($"== Root ==\n{root.OuterHTML}");
+    Console.WriteLine("\n\n== Visitor CSS ==");
+    Console.WriteLine(string.Join("\n", parser.Classes.ToArray()));
+    Console.WriteLine("\n\n== Visitor texts ==");
+    Console.WriteLine(string.Join("\n", parser.Texts.ToArray()));
+}
 
 static void State()
 {
@@ -63,6 +76,9 @@ static LightElementNode GenerateRoot()
 
     var img = new LightElementNode("img", closing: ClosingType.SelfClosing);
     img.AddClass("responsive");
+
+    div.AddChild(h1);
+    div.AddChild(p);
 
     root.AddChild(div);
     root.AddChild(div);

--- a/mkr1/mkr1/Visitor/HTMLParserVisitor.cs
+++ b/mkr1/mkr1/Visitor/HTMLParserVisitor.cs
@@ -1,0 +1,24 @@
+﻿using mkr1.LightHTML;
+
+namespace mkr1.Visitor
+{
+    public class HTMLParserVisitor : IVisitor
+    {
+        private readonly HashSet<string> _classes = new HashSet<string>();
+        public IReadOnlyCollection<string> Classes => _classes;
+
+        private readonly HashSet<string> _texts = new HashSet<string>();
+        public IReadOnlyCollection<string> Texts => _texts;
+
+        public void Visit(LightTextNode textNode)
+        {
+            _texts.Add(textNode.InnerHTML);
+        }
+
+        public void Visit(LightElementNode elementNode)
+        {
+            foreach (var cls in elementNode.CssClasses)
+                _classes.Add(cls);
+        }
+    }
+}

--- a/mkr1/mkr1/Visitor/IVisitable.cs
+++ b/mkr1/mkr1/Visitor/IVisitable.cs
@@ -1,0 +1,7 @@
+﻿namespace mkr1.Visitor
+{
+    public interface IVisitable
+    {
+        void Accept(IVisitor visitor);
+    }
+}

--- a/mkr1/mkr1/Visitor/IVisitor.cs
+++ b/mkr1/mkr1/Visitor/IVisitor.cs
@@ -1,0 +1,10 @@
+﻿using mkr1.LightHTML;
+
+namespace mkr1.Visitor
+{
+    public interface IVisitor
+    {
+        void Visit(LightTextNode textNode);
+        void Visit(LightElementNode elementNode);
+    }
+}

--- a/mkr1/mkr1/mkr1.csproj
+++ b/mkr1/mkr1/mkr1.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <Folder Include="TempleteMethod\" />
-    <Folder Include="Visitor\" />
   </ItemGroup>
 
 </Project>

--- a/mkr1/mkr1/outputExample.txt
+++ b/mkr1/mkr1/outputExample.txt
@@ -1,3 +1,18 @@
+=== Visitor ===
+== Root ==
+<div class="container"><div class="small-container"><h1>Welcome to LightHTML</h1><p>This is a custom markup example.</p></div><div class="small-container"><h1>Welcome to LightHTML</h1><p>This is a custom markup example.</p></div><div class="small-container"><h1>Welcome to LightHTML</h1><p>This is a custom markup example.</p></div></div>
+
+
+== Visitor CSS ==
+container
+small-container
+
+
+== Visitor texts ==
+Welcome to LightHTML
+This is a custom markup example.
+
+
 === Template Method ===
 == div.addChild(p) ==
 LightElementNode class list applied!

--- a/mkr1/readme.md
+++ b/mkr1/readme.md
@@ -1,3 +1,41 @@
+# Visitor
+- Implemented interfaces `IVisitable` and `IVisitor`  
+- Next classes now implements `Accept` method to have `Visitor`:         
+-- `LightNode`  
+-- `LightTextNode`  
+-- `LightElementNode`  
+- `HTTPParserVisitor` collects all unique css styles and all unique texts recursively
+
+### Output examples:
+
+Example fragment:  
+```c#
+== Root ==
+<div class="container">
+    <div class="small-container">
+        <h1>Welcome to LightHTML</h1>
+        <p>This is a custom markup example.</p>
+    </div>
+    <div class="small-container">
+        <h1>Welcome to LightHTML</h1>
+        <p>This is a custom markup example.</p>
+    </div>
+    <div class="small-container">
+        <h1>Welcome to LightHTML</h1>
+        <p>This is a custom markup example.</p>
+    </div>
+</div>
+
+== Visitor CSS ==
+container
+small-container
+
+== Visitor texts ==
+Welcome to LightHTML
+This is a custom markup example.
+```
+
+
 # Template Method
 - Implemented `template method` in `LightNode` and `LightElementNode`
 - Implemented life hooks:     


### PR DESCRIPTION
# Visitor
- Implemented interfaces `IVisitable` and `IVisitor`  
- Next classes now implements `Accept` method to have `Visitor`:         
-- `LightNode`  
-- `LightTextNode`  
-- `LightElementNode`  
- `HTTPParserVisitor` collects all unique css styles and all unique texts recursively

### Output examples:

Example fragment:  
```c#
== Root ==
<div class="container">
    <div class="small-container">
        <h1>Welcome to LightHTML</h1>
        <p>This is a custom markup example.</p>
    </div>
    <div class="small-container">
        <h1>Welcome to LightHTML</h1>
        <p>This is a custom markup example.</p>
    </div>
    <div class="small-container">
        <h1>Welcome to LightHTML</h1>
        <p>This is a custom markup example.</p>
    </div>
</div>

== Visitor CSS ==
container
small-container

== Visitor texts ==
Welcome to LightHTML
This is a custom markup example.
```